### PR TITLE
포럼 버튼 텍스트 미표출 문제 해결

### DIFF
--- a/themes/ubuntukr/layouts/about/list.html
+++ b/themes/ubuntukr/layouts/about/list.html
@@ -30,7 +30,7 @@
       <div class="col-8">
         <h1>{{i18n "about_online_title"}}</h1>
         <p>{{i18n "about_online_desc"}}</p>
-        <a href="https://discourse.ubuntu-kr.org"><button class="p-button">{{i18n "forums"}}</button></a>
+        <a href="https://discourse.ubuntu-kr.org"><button class="p-button">{{i18n "forums_discourse"}}</button></a>
         <a href="../chat"><button class="p-button">{{i18n "chat"}}</button></a>
         <a href="https://wiki.ubuntu-kr.org/"><button class="p-button">{{i18n "wiki"}}</button></a>
       </div>


### PR DESCRIPTION
<img width="748" alt="image" src="https://github.com/ubuntu-kr/ubuntu-kr.github.io/assets/99532497/30206a40-8c9f-4451-925c-96bda892cc54">

/about 페이지의 포럼 이동 버튼의 텍스트가 `{{i18n "forums"}}` 으로 되어있어 아무런 텍스트가 표출되지 않는 상황이었습니다.
`{{i18n "forums_discourse"}}` 으로 변경하여 문제를 수정했습니다.